### PR TITLE
Bugfix: Updater crash

### DIFF
--- a/Stringz.xcodeproj/project.pbxproj
+++ b/Stringz.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0425E16329E7D4DF001A225A /* UpdaterController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0425E16229E7D4DF001A225A /* UpdaterController.swift */; };
 		712CBE8E259A79D100204E11 /* StoryboardPreferenceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712CBE8D259A79D100204E11 /* StoryboardPreferenceViewController.swift */; };
 		713D9A572573E6E400B1CE76 /* LocalizableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 713D9A562573E6E400B1CE76 /* LocalizableType.swift */; };
 		71432575257AC064005E78E9 /* AppNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71432574257AC064005E78E9 /* AppNotifications.swift */; };
@@ -62,6 +63,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0425E16229E7D4DF001A225A /* UpdaterController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterController.swift; sourceTree = "<group>"; };
 		712CBE8D259A79D100204E11 /* StoryboardPreferenceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryboardPreferenceViewController.swift; sourceTree = "<group>"; };
 		713D9A562573E6E400B1CE76 /* LocalizableType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizableType.swift; sourceTree = "<group>"; };
 		71432574257AC064005E78E9 /* AppNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppNotifications.swift; sourceTree = "<group>"; };
@@ -180,6 +182,7 @@
 				71B371F9259F6036003DB79E /* Preferences */,
 				71B37211259F89FF003DB79E /* StringzApp.swift */,
 				7183A5511EE81960007E88FF /* AppDelegate.swift */,
+				0425E16229E7D4DF001A225A /* UpdaterController.swift */,
 				7183A5771EE81AFD007E88FF /* MainWindowController.swift */,
 				7183A5781EE81AFD007E88FF /* MainViewController.swift */,
 				7183A5791EE81AFD007E88FF /* SidebarViewController.swift */,
@@ -296,7 +299,6 @@
 				TargetAttributes = {
 					7183A54D1EE81960007E88FF = {
 						CreatedOnToolsVersion = 8.3.3;
-						DevelopmentTeam = PHGV4R6G9J;
 						LastSwiftMigration = 1200;
 						ProvisioningStyle = Automatic;
 					};
@@ -383,6 +385,7 @@
 				71B37216259FA839003DB79E /* AppMenuItems.swift in Sources */,
 				71B37212259F89FF003DB79E /* StringzApp.swift in Sources */,
 				7183A5521EE81960007E88FF /* AppDelegate.swift in Sources */,
+				0425E16329E7D4DF001A225A /* UpdaterController.swift in Sources */,
 				71F4F92A25963D0D00743CB7 /* AppToolbarItems.swift in Sources */,
 				71E0DB4725A0FC810097F5B5 /* AppScenes.swift in Sources */,
 				71E2EB14252CB1E400A9C9AC /* File.swift in Sources */,
@@ -514,7 +517,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 44;
-				DEVELOPMENT_TEAM = PHGV4R6G9J;
+				DEVELOPMENT_TEAM = 8W5R4SG47B;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = Stringz/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -538,7 +541,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 44;
-				DEVELOPMENT_TEAM = PHGV4R6G9J;
+				DEVELOPMENT_TEAM = 8W5R4SG47B;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = Stringz/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Stringz/AppDelegate.swift
+++ b/Stringz/AppDelegate.swift
@@ -11,7 +11,6 @@ import AppCenter
 import AppCenterAnalytics
 import AppCenterCrashes
 import PathKit
-import Sparkle
 import Preferences
 import Combine
 import ValueTransformerKit
@@ -19,8 +18,8 @@ import ValueTransformerKit
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
   @IBOutlet weak var menuItemAddLanguage: NSMenuItem!
-  @IBOutlet weak var updaterController: SPUStandardUpdaterController!
-
+  lazy var updaterController = UpdaterController()
+  
   private var isOpenPanelRunning = false
   private var isQuitting = false
   private var openProjectCountSubscriber: AnyCancellable?
@@ -189,7 +188,7 @@ extension AppDelegate {
       self.continueQuitting(didClose: true)
       return .terminateLater
     } else {
-      let _ = Common.alert(
+      Common.alert(
         message: "You have \(unsavedWindows.count) Stringz projects with unconfirmed changes. Do you want to review these changes before quitting?",
         informative: "If you dont review your projects, all changes will be saved.",
         positiveButton: "Review Changes...",

--- a/Stringz/Common.swift
+++ b/Stringz/Common.swift
@@ -11,6 +11,7 @@ import Cocoa
 class Common {
   private static var textFieldDelegate = EmptyTextFieldDelegate()
 
+  @discardableResult
   static func alert(message: String = "", informative: String = "",
                     positiveButton: String = "OK", negativeButton: String? = nil, neutralButton: String? = nil,
                     window: NSWindow? = nil, completion: ((NSApplication.ModalResponse) -> Void)? = nil) -> NSAlert {

--- a/Stringz/GeneralPreference.xib
+++ b/Stringz/GeneralPreference.xib
@@ -8,6 +8,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="GeneralPreferenceViewController" customModule="Stringz" customModuleProvider="target">
             <connections>
+                <outlet property="automaticallyCheckForUpdatesButton" destination="dro-29-ca7" id="HmZ-64-gRC"/>
+                <outlet property="automaticallyDownloadUpdatesButton" destination="Y3n-XA-hbz" id="gjE-ir-uf3"/>
                 <outlet property="view" destination="c22-O7-iKe" id="imP-dv-zVJ"/>
             </connections>
         </customObject>

--- a/Stringz/GeneralPreferenceViewController.swift
+++ b/Stringz/GeneralPreferenceViewController.swift
@@ -14,20 +14,34 @@ final class GeneralPreferenceViewController: PreferenceViewController, Preferenc
   let preferencePaneTitle = "General"
   let toolbarItemIcon = NSImage(named: "preferences.general")!
   override var nibName: NSNib.Name? { "GeneralPreference" }
-
-  override func viewDidLoad() {
-    super.viewDidLoad()
-  }
-
+  
   var appDelegate: AppDelegate {
     NSApplication.shared.delegate as! AppDelegate
   }
-
-  @IBAction func automaticallyCheckForUpdatesChanged(_ sender: NSButton) {
-    appDelegate.updaterController.updater.automaticallyChecksForUpdates = sender.state == .on
+  
+  @IBOutlet weak var automaticallyCheckForUpdatesButton: NSButton?
+  @IBOutlet weak var automaticallyDownloadUpdatesButton: NSButton?
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
   }
-
+  
+  override func viewWillAppear() {
+    super.viewWillAppear()
+    
+    automaticallyCheckForUpdatesButton?.state = appDelegate.updaterController.automaticallyChecksForUpdates ? .on : .off
+    
+    automaticallyDownloadUpdatesButton?.state = appDelegate.updaterController.automaticallyDownloadsUpdates ? .on : .off
+    
+  }
+  
+  
+  
+  @IBAction func automaticallyCheckForUpdatesChanged(_ sender: NSButton) {
+    appDelegate.updaterController.setAutomaticallyChecksForUpdates(sender.state == .on)
+  }
+  
   @IBAction func automaticallyDownloadUpdatesChanged(_ sender: NSButton) {
-    appDelegate.updaterController.updater.automaticallyDownloadsUpdates = sender.state == .on
+    appDelegate.updaterController.setAutomaticallyDownloadsUpdates(sender.state == .on)
   }
 }

--- a/Stringz/UpdaterController.swift
+++ b/Stringz/UpdaterController.swift
@@ -1,0 +1,38 @@
+//
+//  UpdaterController.swift
+//  Stringz
+//
+//  Created by Maurice Arikoglu on 13.04.23.
+//
+
+import Foundation
+import Sparkle
+
+class UpdaterController: NSObject {
+  
+  private lazy var sparkle: SPUStandardUpdaterController = {
+    return .init(updaterDelegate: self, userDriverDelegate: self)
+  }()
+  
+  public var automaticallyChecksForUpdates: Bool {
+    return sparkle.updater.automaticallyChecksForUpdates
+  }
+  
+  public var automaticallyDownloadsUpdates: Bool {
+    return sparkle.updater.automaticallyDownloadsUpdates
+  }
+
+  public func setAutomaticallyChecksForUpdates(_ on: Bool) {
+    sparkle.updater.automaticallyChecksForUpdates = on
+  }
+  
+  public func setAutomaticallyDownloadsUpdates(_ on: Bool) {
+    sparkle.updater.automaticallyDownloadsUpdates = on
+  }
+  
+}
+
+extension UpdaterController: SPUStandardUserDriverDelegate, SPUUpdaterDelegate {
+  
+  
+}


### PR DESCRIPTION
The Updater implementation was not working, as the SPUStandardUpdaterController was never initialized, this led to an unexpected nil crash (force unwrap).
Also the interface did not reflect the user preference state as no IBOutlets were connected, this is also fixed.